### PR TITLE
Use correct homepage URL

### DIFF
--- a/fluent-plugin-logit.gemspec
+++ b/fluent-plugin-logit.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.email         = ["support@logit.io"]
   s.description   = %q{Logit output plugin for Fluentd}
   s.summary       = %q{Fluentd output plugin to store data with logit.io}
-  s.homepage      = "https://github.com/logit/fluent-plugin-logit"
+  s.homepage      = "https://github.com/logit-io/fluent-plugin-logit"
   s.license       = 'MIT'
 
   s.files         = `git ls-files`.split($/)


### PR DESCRIPTION
[List of All Plugins](https://www.fluentd.org/plugins/all) page uses this metadata.

Otherwise, users get 404 on this plugin link:


1827 | [logit](https://github.com/logit/fluent-plugin-logit) | Logit | Logit output plugin for Fluentd | 0.1.0
-- | -- | -- | -- | --


